### PR TITLE
fix(debugging-patterns): trace config to SDK consumers before refactors

### DIFF
--- a/plugins/cc10x/skills/debugging-patterns/SKILL.md
+++ b/plugins/cc10x/skills/debugging-patterns/SKILL.md
@@ -290,6 +290,15 @@ You MUST complete each phase before proceeding to the next.
    - Keep tracing up until you find the source
    - Fix at source, not at symptom
 
+6. **Trace configuration to its consumer (third-party SDKs, env, import time)**
+
+   **BEFORE proposing replacements, migrations, or large refactors:**
+
+   - **Option Zero:** Can this be fixed with **only** a configuration or environment change? State and test that hypothesis *before* you propose code rewrites. Many integration bugs are wiring problems, not architecture problems.
+   - When an env var is validated in application config but **never passed into** library constructors, ask **who reads it?** Third-party SDKs often read `process.env` (or language equivalents) at **module import / load time**—not through your app's DI or config objects. The fix may be setting or correcting env, not changing application code.
+   - **Before** proposing to replace a third-party SDK, spend a short cycle on **how** it is configured: package README, official docs, or the installed source under `node_modules` (or vendor path). The failure may be a wrong endpoint or flag, not a need for a different library.
+   - When code comments describe **import-time** behavior or env-var dependencies, treat them as **investigation breadcrumbs**, not decoration—follow them to the real consumer.
+
 ### Phase 2: Pattern Analysis
 
 **Find the pattern before fixing:**
@@ -486,6 +495,7 @@ If you catch yourself thinking:
 - "Pattern says X but I'll adapt it differently"
 - "Here are the main problems: [lists fixes without investigation]"
 - Proposing solutions before tracing data flow
+- Proposing SDK replacement or a large migration before ruling out a **config-only** fix (Option Zero) and tracing **who** reads env / config at import time
 - **"One more fix attempt" (when already tried 2+)**
 - **Each fix reveals new problem in different place**
 


### PR DESCRIPTION
## Summary

- Adds **Phase 1** investigation step **Trace configuration to its consumer (third-party SDKs, env, import time)** in `plugins/cc10x/skills/debugging-patterns/SKILL.md`: prioritize an **Option Zero** config/env-only fix, trace who reads env when it is not passed through constructors (including import-time `process.env` usage), verify configuration via docs or installed sources before proposing SDK replacement, and treat comments about import-time behavior as investigation breadcrumbs.
- Extends the anti-pattern list with proposing SDK replacement or large migration before ruling out a config-only fix and tracing env/config consumers at import time.

Addresses the workflow described in #18 (trace configuration to consumers before jumping to replacements).

## How to test

From the repository root:

```bash
python3 plugins/cc10x/scripts/cc10x_harness_audit.py && python3 plugins/cc10x/scripts/cc10x_workflow_replay_check.py
```

Fixes #18