### PR TITLE
feat(review-package): target a configurable repo via --repo / CC10X_REPO_DIR

### DIFF
--- a/plugins/cc10x/scripts/cc10x_review_package.py
+++ b/plugins/cc10x/scripts/cc10x_review_package.py
@@ -4,13 +4,19 @@ extended context, written to one file the reviewer reads in a single call, so
 the diff never has to be pasted through the router's context. cc10x's analog of
 superpowers' review-package.
 
-Usage: cc10x_review_package.py BASE [HEAD]
+Usage: cc10x_review_package.py [--repo DIR] BASE [HEAD]
   BASE   the sha/ref recorded BEFORE the phase started
   HEAD   end ref (default HEAD)
+  --repo the git repo to diff (default: $CC10X_REPO_DIR, else the process cwd).
+         Lets the router drive a build against a repo OTHER than the process
+         cwd (a sibling repo, or one repo reached from a parent dir) so the
+         review/verify diff targets the repo that actually changed.
 
 Writes <state_root>/review-<base7>..<head7>.diff (state_root = .cc10x, resolved
 like the hooklib: CLAUDE_PROJECT_DIR env, else git toplevel, else cwd) and
-prints 'wrote <path>: <n> commit(s), <bytes> bytes'.
+prints 'wrote <path>: <n> commit(s), <bytes> bytes'. NOTE: --repo / CC10X_REPO_DIR
+only redirects the git QUERIES; the package is still written to the standard
+state_root (so the orchestrator reads it where it always does).
 
 CRITICAL: BASE must be the sha recorded before the phase started, NEVER HEAD~1.
 HEAD~1 silently drops all but the last commit of a multi-commit phase, so the
@@ -47,12 +53,22 @@ def state_root() -> Path:
     return path
 
 
+def repo_dir() -> str | None:
+    """The git repo the diff queries run against. `CC10X_REPO_DIR` lets the
+    router drive a build against a repo OTHER than the process cwd; unset
+    returns None so git runs in the process cwd exactly as before (default
+    behavior is unchanged). project_dir()/state_root() are intentionally NOT
+    affected — only the git source moves, not where the package is written."""
+    return os.environ.get("CC10X_REPO_DIR") or None
+
+
 def git(*args: str) -> str:
     return subprocess.run(
         ["git", *args],
         capture_output=True,
         text=True,
         check=True,
+        cwd=repo_dir(),
     ).stdout
 
 
@@ -71,7 +87,18 @@ def main() -> int:
     )
     parser.add_argument("base", help="sha/ref recorded BEFORE the phase started")
     parser.add_argument("head", nargs="?", default="HEAD", help="end ref (default HEAD)")
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="git repo to diff (default: $CC10X_REPO_DIR, else cwd). Lets the "
+        "router review a repo other than the process cwd.",
+    )
     args = parser.parse_args()
+
+    # --repo takes precedence over the env; both feed git() via CC10X_REPO_DIR
+    # so every git query in this run targets the same repo.
+    if args.repo:
+        os.environ["CC10X_REPO_DIR"] = args.repo
 
     print(
         "note: BASE must be the sha recorded before the phase started, "

--- a/plugins/cc10x/scripts/test_cc10x_review_package.py
+++ b/plugins/cc10x/scripts/test_cc10x_review_package.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Self-contained test for cc10x_review_package.py's --repo / CC10X_REPO_DIR.
+
+No framework: builds two throwaway git repos (A = process cwd, B = a sibling)
+and asserts the review package targets the right one — including that the
+DEFAULT still targets cwd (regression guard), so the new knob is purely additive.
+
+Lives in scripts/ because the repo's .gitignore tracks .py only under scripts/.
+Run:  python3 test_cc10x_review_package.py    (exit 0 = pass)
+"""
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parent / "cc10x_review_package.py"
+
+
+def run_git(repo: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(repo), *args], check=True, capture_output=True, text=True)
+
+
+def rev(repo: Path, ref: str = "HEAD") -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", ref], capture_output=True, text=True, check=True
+    ).stdout.strip()
+
+
+def make_repo(repo: Path, marker: str) -> tuple[str, str]:
+    """Two commits; the second adds <marker>.txt so we can identify the repo in the diff."""
+    repo.mkdir(parents=True, exist_ok=True)
+    run_git(repo, "init", "-q")
+    run_git(repo, "config", "user.email", "t@example.com")
+    run_git(repo, "config", "user.name", "tester")
+    # repo-specific base content so the two repos' base shas never collide
+    # (identical commits made in the same second would hash equal).
+    (repo / "README.md").write_text(f"base for {marker}\n")
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", "base")
+    base = rev(repo)
+    (repo / f"{marker}.txt").write_text(f"change in {marker}\n")
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-q", "-m", f"feat: add {marker}")
+    return base, rev(repo)
+
+
+def run_script(cwd: Path, env_repo: str | None, args: list[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("CC10X_REPO_DIR", None)
+    if env_repo:
+        env["CC10X_REPO_DIR"] = env_repo
+    env["CLAUDE_PROJECT_DIR"] = str(cwd)  # pin output dir so we can find the package
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args], cwd=str(cwd), env=env, capture_output=True, text=True
+    )
+
+
+def wrote_path(stdout: str) -> str | None:
+    m = re.search(r"wrote (\S+):", stdout)
+    return m.group(1) if m else None
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as tmp:
+        a, b = Path(tmp) / "repoA", Path(tmp) / "repoB"
+        base_a, head_a = make_repo(a, "A_FILE")
+        base_b, head_b = make_repo(b, "B_FILE")
+        ok = True
+
+        # [1] default (cwd=A, no knob) -> diffs A
+        r = run_script(a, None, [base_a, head_a])
+        p = wrote_path(r.stdout)
+        c1 = r.returncode == 0 and p and "A_FILE" in Path(p).read_text()
+        print(f"[1] default targets cwd repo A: {'PASS' if c1 else 'FAIL'} (rc={r.returncode})")
+        ok &= bool(c1)
+
+        # [2] CC10X_REPO_DIR=B (cwd=A) -> diffs B (B's shas only resolve in B)
+        r = run_script(a, str(b), [base_b, head_b])
+        p = wrote_path(r.stdout)
+        c2 = r.returncode == 0 and p and "B_FILE" in Path(p).read_text()
+        print(f"[2] CC10X_REPO_DIR=B diffs B from cwd A: {'PASS' if c2 else 'FAIL'} (rc={r.returncode})")
+        ok &= bool(c2)
+
+        # [3] regression guard: default truly = cwd -> B's shas DON'T resolve in A -> bad BASE (rc 2)
+        r = run_script(a, None, [base_b, head_b])
+        c3 = r.returncode == 2 and "bad BASE" in r.stderr
+        print(f"[3] default does NOT leak to B (rc2 bad BASE): {'PASS' if c3 else 'FAIL'} (rc={r.returncode})")
+        ok &= bool(c3)
+
+        # [4] --repo flag overrides (cwd=A, no env)
+        r = run_script(a, None, ["--repo", str(b), base_b, head_b])
+        p = wrote_path(r.stdout)
+        c4 = r.returncode == 0 and p and "B_FILE" in Path(p).read_text()
+        print(f"[4] --repo B flag overrides: {'PASS' if c4 else 'FAIL'} (rc={r.returncode})")
+        ok &= bool(c4)
+
+    print("ALL PASS" if ok else "FAILURES PRESENT")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/plugins/cc10x/skills/cc10x-router/references/build-workflow.md
+++ b/plugins/cc10x/skills/cc10x-router/references/build-workflow.md
@@ -1,5 +1,12 @@
 ### BUILD preparation
 
+**Target repo (`CC10X_REPO_DIR`) — resolve before everything below.** By default every git command, dependency install, and test run in this workflow operates on the **process cwd**. To drive a build against a repo that is NOT the session cwd (a sibling repo, one package in a multi-repo checkout, or a repo reached from a parent dir), set `CC10X_REPO_DIR` to that repo's absolute path; then for the REST of this workflow:
+- prefix every git command with it — `git -C "$CC10X_REPO_DIR" <cmd>` — covering the `0a` pre-flight, the `11a` per-phase BASE, the final-review `merge-base`, and the finishing checkout/pull/merge/branch/worktree ops;
+- run the `0b` dependency install and the `0c` baseline + every verify test command with that repo as the working directory;
+- pass `--repo "$CC10X_REPO_DIR"` to `scripts/cc10x_review_package.py` (it also reads the env var directly).
+
+The orchestration state dir (`.cc10x/`) and the workflow artifacts STAY at `CLAUDE_PROJECT_DIR` / the session cwd — only the git/build/test SOURCE moves, never where cc10x writes its state. When `CC10X_REPO_DIR` is unset, behavior is exactly as today (process cwd). Record the resolved target under `results.target_repo` so downstream steps and resume use the same repo.
+
 0. **Workspace isolation offer (optional, runs once per workflow, before any builder dispatch).**
    - Skip entirely when `build_scope=trivial` (resolved in step 4) or when already inside a linked worktree. Record `worktree=existing` and continue.
    - If a native worktree primitive is available (a tool named `EnterWorktree`, a `/worktree` command, or a `--worktree` flag), prefer it. In `JUST_GO` mode invoke it on the recommended default; otherwise offer one `AskUserQuestion`: `Isolate in a worktree (Recommended)` or `Work in current branch`. On accept, defer to the native primitive (it owns directory placement, branch creation, and cleanup) and record `worktree=native`.
@@ -56,7 +63,7 @@
 10. Clarify missing requirements before builder only when the plan and memory do not already answer them.
 11. Persist pre-answered clarifications in `activeContext.md ## Decisions` using `Build clarification [{topic}]: {answer}`.
 11a. **Record the per-phase BASE sha (runs each phase, before that phase's builder is dispatched).**
-   - Capture current `HEAD` (`git rev-parse HEAD`) into the workflow artifact under `results.git_base_sha`. Re-record it at the start of EVERY phase, not once per workflow — one sha per phase, overwritten as `phase_cursor` advances.
+   - Capture current `HEAD` (`git rev-parse HEAD`, or `git -C "$CC10X_REPO_DIR" rev-parse HEAD` when a target repo is set — see the Target-repo preamble) into the workflow artifact under `results.git_base_sha`. Re-record it at the start of EVERY phase, not once per workflow — one sha per phase, overwritten as `phase_cursor` advances.
    - This BASE is the producer side of the recorded-BASE discipline: it is exactly what the downstream review / verify / doc agents diff against (`BASE..HEAD`), and it is the BASE argument passed to `scripts/cc10x_review_package.py`. Recording it BEFORE the builder runs guarantees the diff captures only this phase's work, never a prior phase's already-reviewed changes.
    - If `git_preflight=degraded` blocks `git rev-parse`, record `git_base_sha=unavailable` and continue; downstream agents then fall back to reviewing the working-tree diff and say so explicitly.
 12. Builder may execute only the phase at `phase_cursor`.
@@ -187,8 +194,8 @@ cc10x gates EACH phase against its own per-phase BASE, but it never re-reviews t
 - At most once per workflow.
 
 **How it runs (reuse existing machinery — do NOT invent a new agent):**
-1. Compute `MERGE_BASE = git merge-base <base-branch> HEAD`. If `git_preflight=degraded` blocks this, skip the pass and note it.
-2. Produce the whole-branch diff package via `scripts/cc10x_review_package.py MERGE_BASE HEAD` (note: this is `MERGE_BASE..HEAD` across ALL phases, not a single phase's `results.git_base_sha..HEAD`).
+1. Compute `MERGE_BASE = git merge-base <base-branch> HEAD` (use `git -C "$CC10X_REPO_DIR"` when a target repo is set — see the Target-repo preamble). If `git_preflight=degraded` blocks this, skip the pass and note it.
+2. Produce the whole-branch diff package via `scripts/cc10x_review_package.py MERGE_BASE HEAD` (add `--repo "$CC10X_REPO_DIR"` when targeting a non-cwd repo). Note: this is `MERGE_BASE..HEAD` across ALL phases, not a single phase's `results.git_base_sha..HEAD`.
 3. Dispatch exactly ONE `code-reviewer` over that whole-branch package, scoped to cross-phase concerns (seam misuse, contract drift, duplicated/diverged abstractions introduced across phases).
 4. If the reviewer returns findings, run ONE consolidated fix wave — a single remediation `component-builder` addressing all findings together, NOT one fixer per finding — then re-verify with one `integration-verifier` against `results.baseline`. If it returns no findings, record clean and proceed.
 5. Record the outcome in the workflow artifact (`results.final_branch_review`) before advancing to the finishing menu.
@@ -223,7 +230,7 @@ Finishing is a router-owned, optional step that runs AFTER the final phase's `in
 5. Persist the finishing decision into the workflow artifact (`results.finishing.choice`) and append a `build_finished` event to the event log. Then advance to Memory Update.
 
 **Merge-then-cleanup ordering invariant (`Merge to base branch locally`):**
-Execute these steps STRICTLY in order; do not reorder, and do not start teardown until the post-merge gate is green. A branch that was clean before merge can break after merging onto a moved base — that is exactly what the post-merge re-run catches.
+Execute these steps STRICTLY in order; do not reorder, and do not start teardown until the post-merge gate is green. A branch that was clean before merge can break after merging onto a moved base — that is exactly what the post-merge re-run catches. When `CC10X_REPO_DIR` is set, EVERY git command in this block runs against it (`git -C "$CC10X_REPO_DIR" checkout/pull/merge/branch`) and the post-merge test re-run uses it as the working directory — these are destructive ops, so targeting the wrong repo here is the most damaging cwd-confusion of all.
 1. `git checkout <base>` (the branch the work targets).
 2. `git pull` to bring the base up to date.
 3. `git merge <work-branch>` (no force).


### PR DESCRIPTION
Fixes #28.

Makes cc10x able to drive a build against a repo other than the session cwd via an opt-in `CC10X_REPO_DIR` (+ a `--repo` flag). Fully backward-compatible: unset = process cwd, so existing behavior is unchanged.

## 1. `cc10x_review_package.py` — the diff knob

- `--repo DIR` or `CC10X_REPO_DIR` runs the git queries against that repo (precedence: `--repo` > env > cwd).
- The package is still written to the standard `state_root` (`CLAUDE_PROJECT_DIR` / cwd) — only the diff **source** moves, so the orchestrator reads it where it always does. `project_dir()` / `state_root()` are untouched.
- Self-contained stdlib test `scripts/test_cc10x_review_package.py` (placed in `scripts/` because `.gitignore` tracks `.py` only there, via `!plugins/cc10x/scripts/*.py`). Two throwaway git repos; covers default, env var, flag, and a regression guard that the default still targets cwd:

```
[1] default targets cwd repo A: PASS
[2] CC10X_REPO_DIR=B diffs B from cwd A: PASS
[3] default does NOT leak to B (rc2 bad BASE): PASS
[4] --repo B flag overrides: PASS
ALL PASS
```

## 2. `build-workflow.md` — the router honors it end-to-end

The script knob alone only fixes the review/verify **diff**. The router's other build-flow git ops still run in the process cwd. This documents one **Target-repo convention** at the top of BUILD preparation: when `CC10X_REPO_DIR` is set, every git command + the dependency install + the baseline/verify test runs operate on that repo (`git -C` / cwd), and the review-package call gets `--repo`; the `.cc10x/` state and artifacts stay at `CLAUDE_PROJECT_DIR`. Reinforced at the per-phase BASE, the final-review `merge-base`, and the destructive merge-then-cleanup invariant (where targeting the wrong repo would be worst). Instruction-only — no agent/code change.

Together they complete the cross-cwd story described in #28.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
