### PR TITLE
Release-sync v12.5.0: fix 7 harness_audit failures (the last open issue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,56 @@
 # Changelog
 
+## [12.5.0] - 2026-07-16
+
+### Added: Matt Pocock skills integration + enforced seam gate + advisory on-ramp workflows
+
+Three sub-projects integrating Matt Pocock's engineering skills (github.com/mattpocock/skills) into cc10x's autonomous workflow scaffold — Matt's discipline as the payload, cc10x's router as the enforcement. Workflow structure (plan→loop→prove; build→review→integration→verify) untouched across all three.
+
+#### Sub-project 1 — payload layer (commit 7de3f82 + fix 3ad8e9d)
+
+- 2 new skills: `codebase-design` (canonical deep-module vocabulary), `domain-modeling` (active glossary discipline with autonomous transform)
+- `building` Seam Discipline: one-seam/one-test/one-impl + implementation-coupled anti-pattern + advisory TEST_SEAMS
+- `codebase-hygiene` deletion-test bug fix (was inverted — vanishes→keep; now vanishes→pass-through, matching architecture + codebase-design)
+- `architecture` deduped → points to canonical codebase-design
+- `code-reviewer`: 12th Fowler smell (Refused Bequest) + loads codebase-design
+- `planning`: advisory Test Seams + Wide-Refactor expand–contract phasing
+- `debugging`: tighten-the-loop + red-capable completion criteria + REPL-first + measurement-first perf branch + throwaway cleanup
+- `exploration`: active domain-term challenge
+- CONTEXT.md + `docs/adr/` adopted as first-class artifacts; `docs/decisions/` migrated to `docs/adr/`
+- Frontmatter skills: added on 5 agents (active for shaping phases, read-only for builders)
+- 3 GPT-5.6 Sol reviewers (14 findings, all incorporated)
+
+#### Sub-project 2a — enforced seam gate + merge-conflicts skill + router policy gap fixes (PR #56)
+
+- `TEST_SEAMS` + `SEAM_GATE_STATUS` (confirmed/proposed/disagreed/not_applicable) in the builder contract, validated per build_scope
+- `resolving-merge-conflicts` skill (Matt's 5-step, never --abort)
+- Pre-existing router-policy gap fixes: non-empty TDD_RED_REASON, FEEDBACK_LOOP + DEBUG_CLOSEOUT enforcement, ALTERNATIVES ≥2 for decision_rfc
+- Doc-sync fixtures registered in replay (26 fixtures); validators now enforce new fields (4 negative probes)
+- 3 GPT-5.6 Sol reviewers (all findings incorporated)
+
+#### Sub-project 2b — TRIAGE + CODEBASE-HEALTH on-ramp workflows (PR #63)
+
+- 2 new advisory-only intent routes (priority 5 + 6); priority 1-4 unchanged byte-for-byte; DEFAULT→BUILD moved 5→7
+- `triage-agent` (read-only): categorizes/verifies/briefs incoming issues
+- `architecture-scanner` (read-only): surfaces deepening candidates as HTML report
+- Primary-deliverable rules prevent BUILD-stealing; keyword collisions removed
+- workflow_type enum + router substitution list updated (+pending transitional)
+- 3 GPT-5.6 Sol reviewers (all findings incorporated)
+
+#### Verification infrastructure
+
+- `prompt_clause_assertions.py`: 61 anchored assertions (full row text, non-collision checks, tools-line lambda checks)
+- `seam_eval.py`: 6 structural scenarios for the seam gate
+- `workflow_replay_check.py`: 28 fixtures, validators now enforce new contract fields
+- ADRs: `docs/adr/0001-enforced-seam-gate.md`, `docs/adr/0002-advisory-onramp-workflows.md`
+
+### Fixed
+
+- `codebase-hygiene` inverted deletion-test verdict (was contradicting `architecture` + `codebase-design`)
+- `build-doc-sync-happy-path` duplicate `AUDIT_DOCS_UPDATED` key (caught by an independent external-session review)
+- Contract-override policy drift: persona-required fields (TDD_RED_REASON, FEEDBACK_LOOP, DEBUG_CLOSEOUT, ≥2 alternatives) now policy-enforced
+- Doc-sync fixtures orphaned from REQUIRED_FIXTURES — now registered
+
 ## [12.4.0] - 2026-07-05
 
 ### Fixed: Brutal audit findings — de-duplicated skills, wired decorative patterns, hook-enforced circuit breaker

--- a/docs/agent-contract-registry.md
+++ b/docs/agent-contract-registry.md
@@ -1,12 +1,13 @@
 # CC10X Agent Contract Registry
 
 > **Status note:** Aligned to the live agent and router prompt stack as of 2026-06-17 (`v11.0.0`; last structural sync `v10.1.19` on 2026-04-12; `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/`, version held only in `plugin.json`/GitHub; `v11.1.0` adds the SPEC_COMPLIANCE reviewer verdict split + recorded-BASE diffing, additive).
+> **v12.5.0:** adds TEST_SEAMS + SEAM_GATE_STATUS to the component-builder contract; FEEDBACK_LOOP + DEBUG_CLOSEOUT enforcement to bug-investigator; ALTERNATIVES ≥2 for decision_rfc; 2 new read-only agents (triage-agent, architecture-scanner) with router-owned completion; resolving-merge-conflicts skill; CONTEXT.md/docs/adr/ canonical artifacts. Additive — no existing agent contract schema changed.
 > **Purpose:** Quick contract map for maintainers. This document summarizes what the live prompts already enforce; it does not add new behavior.
 
 ## Write Agents
 
 | Agent | Contract type | Completion states | Key blocking signal | Memory payload |
-|------|---------------|-------------------|---------------------|----------------|
+| ------ | --------------- | ------------------- | --------------------- | ---------------- |
 | `component-builder` | YAML `### Router Contract` | `PASS`, `FAIL` | `BLOCKING=true`, `PHASE_STATUS!=completed`, or `PROOF_STATUS!=passed` | `MEMORY_NOTES` |
 | `bug-investigator` | YAML `### Router Contract` | `FIXED`, `INVESTIGATING`, `BLOCKED` | `STATUS!=FIXED` or research escalation | `MEMORY_NOTES` |
 | `planner` | YAML `### Router Contract` | `PLAN_CREATED`, `DECISION_RFC_CREATED`, `NEEDS_CLARIFICATION` | open decisions, failed spec gate, or blocking clarification need | `MEMORY_NOTES` |
@@ -17,10 +18,10 @@
 ## Read-Only Review Agents
 
 | Agent | Primary machine signal | Heading fallback | Completion states |
-|------|-------------------------|------------------|-------------------|
-| `code-reviewer` | `CONTRACT {"s":"APPROVE|CHANGES_REQUESTED","b":...,"cr":...}` | `## Review: Approve` / `## Review: Changes Requested` | `APPROVE`, `CHANGES_REQUESTED` |
-| `silent-failure-hunter` | `CONTRACT {"s":"CLEAN|ISSUES_FOUND","b":...,"cr":...}` | `## Error Handling Audit: CLEAN` / `## Error Handling Audit: ISSUES_FOUND` | `CLEAN`, `ISSUES_FOUND` |
-| `integration-verifier` | `CONTRACT {"s":"PASS|FAIL","b":...,"cr":...}` | `## Verification: PASS` / `## Verification: FAIL` | `PASS`, `FAIL` |
+| ------ | ------------------------- | ------------------ | ------------------- |
+| `code-reviewer` | `CONTRACT {"s":"APPROVE | CHANGES_REQUESTED","b":...,"cr":...}` | `## Review: Approve` / `## Review: Changes Requested` | `APPROVE`, `CHANGES_REQUESTED` |
+| `silent-failure-hunter` | `CONTRACT {"s":"CLEAN | ISSUES_FOUND","b":...,"cr":...}` | `## Error Handling Audit: CLEAN` / `## Error Handling Audit: ISSUES_FOUND` | `CLEAN`, `ISSUES_FOUND` |
+| `integration-verifier` | `CONTRACT {"s":"PASS | FAIL","b":...,"cr":...}` | `## Verification: PASS` / `## Verification: FAIL` | `PASS`, `FAIL` |
 
 All three emit `### Memory Notes (For Workflow-Final Persistence)` instead of YAML
 `MEMORY_NOTES`.

--- a/docs/cc10x-orchestration-bible.md
+++ b/docs/cc10x-orchestration-bible.md
@@ -1,6 +1,6 @@
 # CC10X Orchestration Bible (Plugin-Only Source of Truth)
 
-> **Last reviewed against live plugin files:** 2026-06-17 (`v11.0.0`: workflow/memory state de-versioned from `.cc10x/v10/` to `.cc10x/` — the version now lives only in `plugin.json` and GitHub, never in the state path. Fresh-start on upgrade, no migration. Same harmony-hardened router/agent/skill contracts as the v10.1.x line. `v11.1.0` adds execution-engine scripts + inline fallback + 4 net-new skills, additive.) | **Status:** Reviewed 2026-06-17 — verify any count or contract below against `plugins/cc10x/` before relying on it.
+> **Last reviewed against live plugin files:** 2026-06-17 (`v11.0.0`: workflow/memory state de-versioned from `.cc10x/v10/` to `.cc10x/` — the version now lives only in `plugin.json` and GitHub, never in the state path. Fresh-start on upgrade, no migration. Same harmony-hardened router/agent/skill contracts as the v10.1.x line. `v11.1.0` adds execution-engine scripts + inline fallback + 4 net-new skills, additive.) | **Status:** Reviewed 2026-06-17 — verify any count or contract below against `plugins/cc10x/` before relying on it. **v12.5.0** adds the enforced seam gate (TEST_SEAMS/SEAM_GATE_STATUS), resolving-merge-conflicts skill, CONTEXT.md/docs/adr/ canonical artifacts, 2 new agents (triage-agent, architecture-scanner), and 2 advisory on-ramp workflows (TRIAGE, CODEBASE-HEALTH) — additive, priority 1-4 routes unchanged.
 
 > This document is derived **only** from `plugins/cc10x/` (agents + skills).
 > Ignore all other docs. Do not trust external narratives.
@@ -37,6 +37,7 @@ This document defines the **non-negotiable** routing, tasking, agent chaining, a
 A **skill** is a Markdown file (`SKILL.md`) with optional YAML frontmatter. It provides instructions, reference material, or task workflows that teach Claude how to do something. Skills do NOT execute — they INSTRUCT.
 
 **Skill frontmatter fields:**
+
 ```yaml
 name: skill-name          # Identifier (lowercase, hyphens)
 description: "..."        # When Claude should use this skill
@@ -44,6 +45,7 @@ allowed-tools: Read, Grep # Tools that skip permission prompts when skill is act
 ```
 
 **Key facts:**
+
 - `allowed-tools` is **NOT runtime enforcement**. It defines which tools skip permission prompts. The agent's `tools:` field controls actual tool availability.
 - Skills are loaded as text context.
 - Large preloaded skills increase startup context and contradiction risk.
@@ -59,6 +61,7 @@ allowed-tools: Read, Grep # Tools that skip permission prompts when skill is act
 An **agent** is a Markdown file with YAML frontmatter that defines an isolated subprocess. When invoked via the subagent/task mechanism, Claude Code spawns a new process with its own context window, tools, and instructions.
 
 **Agent frontmatter fields:**
+
 ```yaml
 name: agent-name          # Identifier
 tools: Read, Edit, Bash   # Actual tool allowlist (enforced at runtime)
@@ -69,6 +72,7 @@ model: inherit            # Model to use
 ```
 
 **Key facts:**
+
 - `tools:` is the **actual runtime allowlist**. Agent can ONLY use tools listed here.
 - `skills:` preloads full skill content into the agent's startup context. Keep this list minimal.
 - Agent outputs are returned to the caller (router) as a single result.
@@ -79,7 +83,7 @@ Agents spawned via Agent() run in isolated context windows by default — they c
 ### Skills vs Agents — The Distinction
 
 | Aspect | Skill | Agent |
-|--------|-------|-------|
+| -------- | ------- | ------- |
 | **Nature** | Instructions (text) | Execution unit (subprocess) |
 | **Runs as** | Context injected into an agent | Isolated process with own context window |
 | **Can use tools?** | No — instructs the hosting agent to use tools | Yes — has its own `tools:` allowlist |
@@ -90,6 +94,7 @@ Agents spawned via Agent() run in isolated context windows by default — they c
 ### How CC10x Uses This Architecture
 
 **9 Agents (execution units):**
+
 - `component-builder` — Builds features (has Edit, Write, Bash)
 - `bug-investigator` — Debugs issues (has Edit, Write, Bash)
 - `planner` — Creates plans (has Edit, Write, Bash for plan files; memory persists via `MEMORY_NOTES`)
@@ -101,6 +106,7 @@ Agents spawned via Agent() run in isolated context windows by default — they c
 - `github-researcher` — Executes GitHub research (Octocode MCP); spawned by router in parallel
 
 **13 Skills (instruction sets referenced by agents/router):**
+
 - `cc10x-router` — Orchestration engine (loaded by main Claude, not agents)
 - `session-memory` — Memory protocol (WRITE agents only)
 - `code-generation` — Code writing patterns (component-builder)
@@ -131,6 +137,7 @@ The `cc10x:research` skill provides synthesis guidance (loaded via SKILL_HINTS b
 The router never executes research inline.
 
 **Why this separation:**
+
 1. **Agents are isolated** — code-reviewer cannot accidentally edit files because its `tools:` field excludes Edit/Write. This is enforced by Claude Code, not by English instruction.
 2. **CC10X owns workflow coordination** — workflow metadata, resume logic, remediation loops, and memory conventions are custom CC10X behavior layered above Claude Code primitives.
 3. **Minimal preload beats maximal preload** — only core workflow skills should live in agent frontmatter; everything else should load on demand.
@@ -146,6 +153,7 @@ The router never executes research inline.
 ### Hook-Owned Invariants (Recommended)
 
 Prompt text is not the strongest enforcement layer. These rules should move to hooks or harness code when possible:
+
 - reject Memory Update if anything tries to spawn it as a subagent
 - validate required `wf/kind/origin/phase/plan/scope/reason` metadata on CC10X task creation
 - audit workflow artifact integrity after router-owned writes
@@ -156,6 +164,7 @@ Prompt text is not the strongest enforcement layer. These rules should move to h
 ### Plugin Packaging Rules
 
 For marketplace/plugin installs, shipped runtime behavior must live inside the plugin bundle:
+
 - plugin manifest: `.claude-plugin/plugin.json`
 - plugin hooks: `hooks/hooks.json`
 - plugin hook scripts: `scripts/*` referenced via `${CLAUDE_PLUGIN_ROOT}`
@@ -166,6 +175,7 @@ Repo-local `.claude/settings.json` is not part of the shipped plugin contract.
 ### Stability Harness (Current State)
 
 The current main branch includes two non-runtime but load-bearing safety tools:
+
 - `plugins/cc10x/scripts/cc10x_harness_audit.py`
   - validates manifest/docs/marketplace drift
   - validates shipped hooks and MCP references
@@ -179,6 +189,7 @@ These are part of the maintenance contract even though they are not invoked by t
 ### Router Packaging Rule
 
 The router now uses a **kernel + mandatory workflow playbooks** shape:
+
 - keep universal orchestration law inline in `cc10x-router/SKILL.md`
 - keep workflow-specific and appendix-heavy law in
   `plugins/cc10x/skills/cc10x-router/references/*.md`
@@ -248,6 +259,7 @@ flowchart TD
 ### Task Hierarchies (Canonical)
 
 **BUILD**
+
 - Parent: `CC10X BUILD: {feature_summary}`
 - Agents:
   - `component-builder` (no dependencies)
@@ -257,6 +269,7 @@ flowchart TD
   - `Memory Update` (blocked by integration-verifier) ← TASK-ENFORCED
 
 **DEBUG**
+
 - Parent: `CC10X DEBUG: {error_summary}`
 - Agents:
   - `bug-investigator`
@@ -265,11 +278,13 @@ flowchart TD
   - `Memory Update` (blocked by integration-verifier) ← TASK-ENFORCED
 
 **REVIEW**
+
 - Parent: `CC10X REVIEW: {target_summary}`
 - Agent: `code-reviewer`
 - `Memory Update` (blocked by code-reviewer) ← TASK-ENFORCED
 
 **PLAN**
+
 - Parent: `CC10X PLAN: {feature_summary}`
 - Agents:
   - `planner:create`
@@ -321,20 +336,25 @@ flowchart LR
 **Do not run integration-verifier until BOTH complete.**
 
 ### DEBUG Chain
+
 `bug-investigator → code-reviewer → integration-verifier`
 
 ### REVIEW Chain
+
 `code-reviewer` only
 
 ### PLAN Chain
+
 `planner:create` → `plan-gap-reviewer` pass 1 → `planner:replan` if needed → `plan-gap-reviewer` pass 2 if needed
 
 The planner runs `plan-review-gate` inline before each saved-plan handoff. The router pre-creates the full bounded chain at PLAN start, then prunes unused nodes:
+
 - if pass 1 returns `PASS`, `planner:replan` and pass 2 are marked `deleted`
 - if pass 1 returns `FINDINGS`, the pre-created `planner:replan` node becomes active
 - if pass 2 returns `FINDINGS`, PLAN stops on clarification and memory remains blocked
 
 **Notes:**
+
 - `plan-gap-reviewer` is a fresh read-only subagent. It never owns orchestration, memory, or plan approval.
 - `plan-review-gate` still runs inside the planner agent's context — not a separate router step. BUILD/DEBUG/REVIEW chains are unaffected.
 
@@ -345,11 +365,13 @@ The planner runs `plan-review-gate` inline before each saved-plan handoff. The r
 ### Load (Before Routing)
 
 **Step 1 (MUST complete first):**
+
 ```
 mkdir -p .cc10x
 ```
 
 **Step 2 (AFTER Step 1):**
+
 ```
 Read .cc10x/activeContext.md
 Read .cc10x/patterns.md
@@ -361,11 +383,13 @@ Read .cc10x/progress.md
 ### Update (After Workflow)
 
 **WRITE agents** (component-builder, bug-investigator, planner):
+
 - Read memory directly at task start
 - Emit structured YAML `MEMORY_NOTES`
 - Do **not** edit `.cc10x/*.md` directly
 
 **READ-ONLY agents** (code-reviewer, silent-failure-hunter, integration-verifier):
+
 - Do NOT have Edit tool - cannot update memory directly
 - Output `### Memory Notes (For Workflow-Final Persistence)` section
 - Memory Notes persisted via task-enforced "CC10X Memory Update" task
@@ -373,11 +397,13 @@ Read .cc10x/progress.md
 **Memory load + update are non-negotiable.**
 
 **Parallel safety (BUILD only):**
+
 - During the parallel phase (`code-reviewer ∥ silent-failure-hunter`), **neither agent updates memory**.
 - Both are READ-ONLY and output Memory Notes sections.
 - Memory Update task persists all Memory Notes **after** all agents complete (task-enforced).
 
 **Workflow-Final Memory Persistence (Task-Enforced):**
+
 - Each workflow has a "CC10X Memory Update" task blocked by the final agent
 - When this task becomes available, collect Memory Notes and persist:
   1. Learnings to `activeContext.md ## Learnings`
@@ -388,6 +414,7 @@ Read .cc10x/progress.md
   `references/` so the main skill stays a compact control plane.
 
 **Memory contract (never break anchors):**
+
 - Do not rename the top-level headers or section headers in `.cc10x/*.md`.
 - After any `Edit(...)`, `Read(...)` back and confirm the intended change exists. If not, STOP and retry with a correct `old_string` anchor.
 
@@ -398,12 +425,13 @@ After loading memory files, the router MUST ensure all required sections exist. 
 **Required sections by file:**
 
 | File | Required Sections |
-|------|-------------------|
+| ------ | ------------------- |
 | `activeContext.md` | `## Current Focus`, `## Recent Changes`, `## Next Steps`, `## Decisions`, `## Learnings`, `## References`, `## Blockers`, `## Last Updated` |
 | `progress.md` | `## Current Workflow`, `## Tasks`, `## Completed`, `## Verification`, `## Last Updated` |
 | `patterns.md` | `## Common Gotchas` (minimum) |
 
 **Auto-heal pattern:**
+
 ```
 # If any section missing, insert before ## Last Updated:
 Edit(file_path=".cc10x/activeContext.md",
@@ -423,11 +451,13 @@ This is **idempotent**: runs once per project (subsequent sessions find sections
 ## Research Protocol (Only When Triggered)
 
 Trigger conditions (any one):
+
 - User explicitly requests research (github/best practices/etc).
 - Post-2024 tech or unfamiliar integration.
 - External service error or 3+ failed debug attempts.
 
 Mandatory steps:
+
 1. Execute web research via Bright Data/web fallback and GitHub research via Octocode/GitHub fallback.
 2. Persist to `docs/research/YYYY-MM-DD-<topic>-research.md`.
 3. Update `activeContext.md` with research reference.
@@ -444,7 +474,7 @@ Mandatory steps:
 Only core workflow skills should preload automatically. Keep frontmatter short because preloaded skill text is injected into agent startup context.
 
 | Agent | Frontmatter Skills |
-|-------|-------------------|
+| ------- | ------------------- |
 | component-builder | session-memory, test-driven-development, code-generation, verification-before-completion |
 | code-reviewer | code-review-patterns, verification-before-completion |
 | silent-failure-hunter | code-review-patterns |
@@ -457,12 +487,14 @@ Only core workflow skills should preload automatically. Keep frontmatter short b
 Router passes SKILL_HINTS in agent prompt. Agent invokes via `Skill(skill="{name}")`.
 
 **Sources for SKILL_HINTS:**
+
 1. Approved project/domain skills from `CLAUDE.md` or `patterns.md`
 2. `cc10x:frontend-patterns` when the task is UI/frontend-heavy, involves screenshots/visual preferences, or needs a spec-aligned project-local `DESIGN.md`
 3. `cc10x:architecture-patterns` when the task spans APIs, schemas, auth, integration boundaries, or multiple subsystems
 4. `cc10x:research` when planner or investigator has research files to synthesize
 
 **Critical flow:**
+
 - Router runs in main Claude context → can see project hints
 - Subagents run in isolated context → cannot see those hints directly
 - Router bridges the gap by passing only relevant skills to agents via SKILL_HINTS
@@ -510,7 +542,9 @@ MEMORY_NOTES:
   patterns: ["..."]
   verification: ["..."]
 ```
+
 **CONTRACT RULE:** [Agent-specific validation criteria]
+
 ```
 
 ### READ-ONLY Agent Output Format (code-reviewer, silent-failure-hunter, integration-verifier)
@@ -542,7 +576,7 @@ CONTRACT {"s":"APPROVE|CHANGES_REQUESTED|CLEAN|ISSUES_FOUND|PASS|FAIL","b":true|
 ### Router Contract by Agent
 
 | Agent | Contract Type | STATUS Values | BLOCKING when | Key Fields |
-|-------|--------------|---------------|---------------|-----------|
+| ------- | -------------- | --------------- | --------------- | ----------- |
 | component-builder | YAML | PASS, FAIL | Contract says so | TDD_RED_EXIT, TDD_GREEN_EXIT, REMEDIATION_REASON |
 | bug-investigator | YAML | FIXED, INVESTIGATING, BLOCKED | STATUS != FIXED | ROOT_CAUSE, NEEDS_EXTERNAL_RESEARCH |
 | planner | YAML | PLAN_CREATED, NEEDS_CLARIFICATION | Router decides from status | PLAN_FILE, CONFIDENCE, GATE_PASSED, USER_INPUT_NEEDED |
@@ -555,20 +589,24 @@ CONTRACT {"s":"APPROVE|CHANGES_REQUESTED|CLEAN|ISSUES_FOUND|PASS|FAIL","b":true|
 Router validation is two-track:
 
 **WRITE agents (YAML)**
+
 1. Parse `### Router Contract (MACHINE-READABLE)`.
 2. Validate required fields for the agent.
 3. Apply contract-rule overrides if the output contradicts required evidence.
 
 **READ-ONLY agents (envelope-first)**
+
 1. Parse line 1 `CONTRACT {json}`.
 2. If envelope parsing fails, parse the stable heading on line 2.
 3. Count bullets in `### Critical Issues` to confirm or override `cr`.
 4. Use task state to detect self-remediation or downstream blocking.
 
 JUST_GO:
+
 - If `AUTO_PROCEED: true` in `activeContext.md ## Session Settings`, auto-default all non-REVERT user gates to the recommended option and log the choice.
 
 Validation rules:
+
 - `component-builder`: missing RED/GREEN evidence forces `STATUS=FAIL`.
 - `bug-investigator`: `STATUS=FIXED` without real fix evidence forces `STATUS=FAIL` unless `NEEDS_EXTERNAL_RESEARCH=true`.
 - `code-reviewer` and `silent-failure-hunter`: any critical issue forces the blocking status.
@@ -590,6 +628,7 @@ reason:{short reason or N/A}
 ```
 
 Rules:
+
 - `wf:` is mandatory on every task.
 - `kind:` is the primary routing key for resume, counting, and task execution.
 - `origin:` and `scope:` are mandatory on every `kind:remfix` task.
@@ -599,7 +638,7 @@ Rules:
 ### Task Types
 
 | Type | Subject Prefix | Required Metadata | Purpose |
-|------|---------------|-------------------|---------|
+| ------ | --------------- | ------------------- | --------- |
 | Workflow | `CC10X BUILD:` / `DEBUG:` / `REVIEW:` / `PLAN:` | `wf`, `kind:workflow`, `origin:router`, `phase`, `plan` | Parent workflow state |
 | Agent | `CC10X {agent}:` | `wf`, `kind:agent`, `origin:router`, `phase`, `plan` | Agent work item |
 | Remediation | `CC10X REM-FIX:` | `wf`, `kind:remfix`, `origin`, `phase`, `plan`, `scope`, `reason` | Deterministic self-healing |
@@ -634,12 +673,14 @@ When a `kind:remfix` task completes:
 6. Re-block the `kind:memory` task on the verifier so persistence happens last.
 
 Routing for remediation tasks is metadata-driven:
+
 - `origin:bug-investigator` → bug-investigator executes the REM-FIX.
 - `origin:code-reviewer|silent-failure-hunter|integration-verifier` → component-builder executes the REM-FIX.
 
 ### Agent Invocation Template
 
 The router passes:
+
 - `Task ID`
 - `Parent Workflow ID`
 - `Plan File`
@@ -649,6 +690,7 @@ The router passes:
 - `SKILL_HINTS`
 
 Rules:
+
 - WRITE agents emit `### Human Layer` and YAML router contract.
 - READ-ONLY agents emit line-1 envelope, line-2 heading fallback, and `### Memory Notes`.
 - Agents must never tell the user they are complete without either calling their valid task tool or letting the router complete them via fallback.
@@ -680,6 +722,7 @@ Rules:
 ## Concurrent Session Warning
 
 `.cc10x/` memory files are single-tenant. Running multiple cc10x sessions concurrently in the **same repository directory** causes:
+
 - Silent data corruption (progress.md pre-populated with wrong data)
 - Memory files overwritten mid-workflow by sibling sessions
 - No error — failures are invisible
@@ -700,15 +743,18 @@ Rules:
 ```
 
 **State Transitions:**
+
 - `pending` → `in_progress`: When agent starts work
 - `in_progress` → `completed`: When agent finishes
 - Any → `deleted`: When task removed
 
 **A task is available when:**
+
 - status = `pending`
 - blockedBy list is empty (all dependencies resolved)
 
 **Blocked Tasks:**
+
 - Task with non-empty `blockedBy` cannot become `in_progress`
 - When blocking task completes, blocked task automatically becomes available
 
@@ -730,7 +776,7 @@ This is why Memory Notes survive compaction and cross-turn truncation.
 ## Key Loop Caps (Safety Mechanisms)
 
 | Cap | Location | Threshold | Purpose |
-|-----|----------|-----------|---------|
+| ----- | ---------- | ----------- | --------- |
 | Circuit Breaker | Before REM-FIX creation | 3 active REM-FIX tasks | Detects pile-up of simultaneous fixes |
 | Cycle Cap | Start of Re-Review Loop | 2 completed REM-FIX tasks | Detects recurring fix loops |
 | INVESTIGATING cap | rule 2c | 3 re-invocations | Prevents infinite investigation |
@@ -769,7 +815,7 @@ These skills run inline inside an agent context and do not own orchestration sta
 These are the current guarantees enforced by the live router/agent files:
 
 | Guarantee | Enforced By |
-|-----------|-------------|
+| ----------- | ------------- |
 | Memory Update always runs inline in the router | Router chain execution loop + `kind:memory` |
 | Resume is workflow-scoped, not task-ID-scoped | Router hydration rules using `wf:` + `kind:` |
 | `memory_task_id` is a transient optimization only | Router hydration rules + session-memory skill |

--- a/docs/cc10x-orchestration-logic-analysis.md
+++ b/docs/cc10x-orchestration-logic-analysis.md
@@ -2,6 +2,7 @@
 
 > **Last synced with live router/agents:** 2026-06-17 (`v11.0.0`; last structural sync `v10.1.19` on 2026-04-12; `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/`, version held only in `plugin.json`/GitHub; `v11.1.0` adds execution-engine deltas + 4 net-new skills, additive)
 > **Status:** SYNCED TO LIVE PROMPTS
+> **v12.5.0:** adds the enforced seam gate, resolving-merge-conflicts skill, CONTEXT.md/docs/adr/ canonical artifacts, 2 new agents (triage-agent, architecture-scanner), and 2 advisory on-ramp workflows (TRIAGE priority 5, CODEBASE-HEALTH priority 6) — additive, priority 1-4 routes unchanged.
 > **Relationship to Bible:** The bible is the canonical specification. This document explains the practical mechanics and why the system is shaped this way.
 
 ## What CC10X Actually Is
@@ -9,11 +10,13 @@
 CC10X is a **Claude Code plugin-native orchestration harness**.
 
 It is not:
+
 - a standalone agent service
 - an issue tracker worker
 - a hidden repo-local sidecar
 
 It is:
+
 - one router skill
 - a small set of specialized agents
 - a small set of plugin hooks
@@ -22,6 +25,7 @@ It is:
 - workflow artifacts under `.cc10x/workflows/`
 
 The system is still mostly **English orchestration**, but it is no longer prompt-only. The current design mixes:
+
 - prompt contracts
 - reference-first skill packaging
 - task metadata
@@ -34,7 +38,9 @@ That mix is the current reliability model.
 ## Current Layers
 
 ### 1. Claude Code platform layer
+
 Owned by Claude Code:
+
 - plugin packaging
 - subagents
 - hooks
@@ -42,7 +48,9 @@ Owned by Claude Code:
 - task primitives
 
 ### 2. CC10X orchestration layer
+
 Owned by this plugin:
+
 - intent routing
 - workflow selection
 - task graph creation
@@ -52,7 +60,9 @@ Owned by this plugin:
 - memory finalization
 
 ### 3. Safety layer
+
 Also owned by this plugin:
+
 - hook guards
 - workflow artifacts
 - workflow event logs
@@ -63,12 +73,16 @@ Also owned by this plugin:
 ## The Real Runtime Flow
 
 ### Entry
+
 The router loads memory, checks for active workflow state, and either:
+
 - resumes a workflow
 - or routes into BUILD / DEBUG / REVIEW / PLAN
 
 ### Workflow state
+
 Every workflow gets:
+
 - a parent task
 - workflow-scoped child tasks
 - `.cc10x/workflows/{wf}.json`
@@ -77,18 +91,23 @@ Every workflow gets:
 This is the durable truth for orchestration.
 
 ### Worker model
+
 Agents are narrow workers:
+
 - write agents produce YAML contracts
 - read-only agents produce envelope-first contracts
 - all agents emit structured memory notes instead of writing markdown memory directly
 - router interprets outputs and owns state transitions
 
 The important design boundary is:
+
 - workers analyze/build/fix/verify
 - router decides what happens next
 
 ### Hook model
+
 Hooks are intentionally small:
+
 - `PreToolUse` protects memory writes
 - `SessionStart` re-injects workflow context
 - `PostToolUse` audits workflow artifact integrity
@@ -99,12 +118,14 @@ Hooks are not a second router.
 ## Why The Current Shape Is Better Than The Old Shape
 
 Older CC10X revisions leaned too hard on:
+
 - very large router prose
 - worker-side orchestration
 - repo-local runtime assumptions
 - memory markdown as live truth
 
 Current main is better because:
+
 - orchestration ownership is centralized
 - the router is now a kernel with mandatory workflow/reference playbooks instead of one giant always-loaded monolith
 - workflow state is durable
@@ -117,6 +138,7 @@ Current main is better because:
 ## The Six SDLC Capabilities CC10X Actually Optimizes
 
 CC10X is intentionally optimized for:
+
 - `PLAN`
 - `BUILD`
 - `DEBUG`
@@ -127,6 +149,7 @@ CC10X is intentionally optimized for:
 It is not trying to be a full deployment/ops/compliance platform.
 
 Within that scope, the current design center is:
+
 - intent-first planning
 - TDD-driven building/debugging
 - adversarial review
@@ -137,6 +160,7 @@ Within that scope, the current design center is:
 ## Where The Remaining Risk Still Lives
 
 Even after the stability hardening, the main remaining risk areas are:
+
 - live Claude runtime behavior under long sessions
 - model interpretation of router prose in unusual edge cases
 - doc drift when trust docs are not refreshed with prompt/runtime edits
@@ -145,6 +169,7 @@ Even after the stability hardening, the main remaining risk areas are:
 - future changes that bypass the replay/audit checks
 
 That is why the safety stack now includes:
+
 - `cc10x_harness_audit.py`
 - `cc10x_workflow_replay_check.py`
 - `router-invariants.md`
@@ -152,6 +177,7 @@ That is why the safety stack now includes:
 ## Maintenance Rule
 
 When changing orchestration, always update in this order:
+
 1. router/runtime behavior
 2. replay fixtures/checker
 3. harness audit

--- a/docs/prompt-invariants.md
+++ b/docs/prompt-invariants.md
@@ -1,6 +1,6 @@
 # CC10X Prompt Behavioral Invariant Registry
 
-> **Status note:** This registry is aligned to the live prompt stack in `plugins/cc10x/agents/` and `plugins/cc10x/skills/` as of 2026-06-17 (`v11.0.0`). Invariants last changed on 2026-04-12 (`v10.1.19`); `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/` (version lives only in `plugin.json`/GitHub) with no invariant changes. `v11.1.0` adds execution-engine deltas and 4 net-new skills — additive, no invariant changes.
+> **Status note:** This registry is aligned to the live prompt stack in `plugins/cc10x/agents/` and `plugins/cc10x/skills/` as of 2026-06-17 (`v11.0.0`). Invariants last changed on 2026-04-12 (`v10.1.19`); `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/` (version lives only in `plugin.json`/GitHub) with no invariant changes. `v11.1.0` adds execution-engine deltas and 4 net-new skills — additive, no invariant changes. `v12.5.0` adds the enforced seam gate, resolving-merge-conflicts skill, CONTEXT.md/docs/adr/ canonical artifacts, and 2 advisory on-ramp workflows (TRIAGE, CODEBASE-HEALTH) — additive, no invariant changes to existing agent contracts.
 
 ## Purpose
 
@@ -16,6 +16,7 @@ the router/runtime lane with audit and replay.
 ## Audit Snapshot
 
 Validated against the live prompt surface:
+
 - planner, component-builder, integration-verifier
 - plan-gap-reviewer
 - plan-review-gate, verification-before-completion
@@ -26,6 +27,7 @@ Validated against the live prompt surface:
 ## Current Invariants
 
 ### PINV-001: Planner cannot silently approve open decisions
+
 **Covers:** `plugins/cc10x/agents/planner.md`
 **Enforces:** Open decisions remain explicit, recommended defaults remain unapproved, and differences from agreement remain visible.
 **Failure prevented:** Planner defaults masquerade as approved requirements.
@@ -34,6 +36,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if the prompt stays non-runtime and does not change router gating semantics.
 
 ### PINV-002: Plan review stays fail-closed and verdict-based
+
 **Covers:** `plugins/cc10x/skills/plan-review-gate/SKILL.md`
 **Enforces:** Review is adversarial, evidence-backed, and binary enough to block execution on unresolved issues.
 **Failure prevented:** “Approved with comments” behavior sneaks back into plan review.
@@ -42,6 +45,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if runtime isolation is not falsely implied.
 
 ### PINV-003: Builder treats the approved phase as the contract
+
 **Covers:** `plugins/cc10x/agents/component-builder.md`
 **Enforces:** The builder follows only the current approved phase, reports scope truthfully, and does not improvise later-phase work.
 **Failure prevented:** Silent phase skipping, hidden scope creep, and narrative success on partial execution.
@@ -50,6 +54,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if it does not add new router-owned checkpoints or task graph behavior.
 
 ### PINV-004: Verifier remains independent from upstream approval
+
 **Covers:** `plugins/cc10x/agents/integration-verifier.md`
 **Enforces:** Reviewer approval, hunter CLEAN, or builder confidence are inputs to verification, never substitutes for proof.
 **Failure prevented:** Self-certified completion where one agent’s confidence is mistaken for verification.
@@ -58,6 +63,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if it does not alter router remediation flow.
 
 ### PINV-005: Verification-before-completion preserves fresh-evidence discipline
+
 **Covers:** `plugins/cc10x/skills/verification-before-completion/SKILL.md`
 **Enforces:** No completion/fix/pass claim without fresh verification evidence from the current session.
 **Failure prevented:** False completion, stale-evidence claims, and “should pass” rationalization.
@@ -66,6 +72,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if it stays wording-only and does not add runtime steps.
 
 ### PINV-006: Internal skills remain advisory under explicit user/project authority
+
 **Covers:** planner, component-builder, integration-verifier, bug-investigator, `frontend-patterns`, `debugging-patterns`
 **Enforces:** User prompt, `CLAUDE.md`, repo standards, and approved plans outrank internal CC10X skills.
 **Failure prevented:** Internal patterns silently competing with explicit project direction.
@@ -74,6 +81,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes.
 
 ### PINV-007: Skill descriptions describe when to use, not workflow summaries
+
 **Covers:** `frontend-patterns`, `debugging-patterns`, `plan-review-gate`, `verification-before-completion`
 **Enforces:** Descriptions stay trigger-oriented and do not summarize workflow steps that Claude may follow instead of reading the body.
 **Failure prevented:** Trigger false positives and workflow shortcuts caused by over-descriptive metadata.
@@ -82,6 +90,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, as long as trigger accuracy improves.
 
 ### PINV-008: Goal-backward verification framing remains intact
+
 **Covers:** `integration-verifier`, `verification-before-completion`
 **Enforces:** Verification still reasons over truths, artifacts, and wiring, not only exit codes or file presence.
 **Failure prevented:** Stubs, unwired implementations, and local illusions passing as complete.
@@ -90,6 +99,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes.
 
 ### PINV-009: Non-trivial plans must be grounded in repo reality
+
 **Covers:** `plugins/cc10x/agents/planner.md`, `plugins/cc10x/skills/plan-review-gate/SKILL.md`
 **Enforces:** Non-trivial plans expose a codebase reality check, plan-vs-code gaps, an assumption ledger, and phase dependencies before they can pass review.
 **Failure prevented:** Plans that look rigorous on paper but ignore the actual codebase and force the user into repeated “compare it to the code again” loops.
@@ -98,6 +108,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if it remains inside planning artifacts and review wording only.
 
 ### PINV-010: Fresh planning review stays reviewer-only
+
 **Covers:** `plugins/cc10x/agents/plan-gap-reviewer.md`, `plugins/cc10x/agents/planner.md`
 **Enforces:** The fresh planning reviewer can challenge the plan, but it cannot rewrite the plan, own memory, ask the user questions, or take over workflow decisions from the planner/router.
 **Failure prevented:** Subagent freshness turning into orchestration drift or multi-owner plan artifacts.
@@ -106,6 +117,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes.
 
 ### PINV-011: Live-proof requirements cannot silently downgrade
+
 **Covers:** `plugins/cc10x/agents/planner.md`, `plugins/cc10x/skills/planning-patterns/SKILL.md`, `plugins/cc10x/agents/integration-verifier.md`, `plugins/cc10x/skills/verification-before-completion/SKILL.md`
 **Enforces:** When the request or accepted plan requires real, seeded, production-like verification, the plan must keep that requirement explicit and the verifier must not substitute replay-only, unit-only, or manual-only checks as equivalent proof.
 **Failure prevented:** CC10X reporting trust-grade verification while only exercising deterministic fixtures or lightweight local checks.
@@ -114,6 +126,7 @@ Validated against the live prompt surface:
 **Safe to strengthen:** Yes, if runtime orchestration ownership remains with the router.
 
 ### PINV-012: Session memory stays router-subordinate and distilled
+
 **Covers:** `plugins/cc10x/skills/session-memory/SKILL.md`
 **Enforces:** Agents load versioned memory early, emit distilled memory notes, and do not bypass router-owned final markdown persistence.
 **Failure prevented:** Duplicate memory write paths, bloated memory notes, and durable-state drift between workflow artifacts and markdown memory.

--- a/docs/prompt-surface-inventory.md
+++ b/docs/prompt-surface-inventory.md
@@ -14,6 +14,7 @@ copy.
 ## Tier 1: Trust-Critical Prompt Contracts
 
 ### planner
+
 - Path: `plugins/cc10x/agents/planner.md`
 - Role: agreement-first planning artifact creation
 - Allowed edits: wording clarity, contract wording, output sections, codebase-reality checks, live-verification planning wording, examples, context-loading guidance
@@ -22,6 +23,7 @@ copy.
 - Review requirement: audit + replay + manual semantic review
 
 ### planning-patterns
+
 - Path: `plugins/cc10x/skills/planning-patterns/SKILL.md`
 - Role: planner save discipline and router-subordinate memory intent guidance
 - Allowed edits: wording clarity, plan-save examples, `MEMORY_NOTES` guidance, live-verification wording
@@ -30,6 +32,7 @@ copy.
 - Review requirement: audit + replay + manual semantic review
 
 ### brainstorming
+
 - Path: `plugins/cc10x/skills/brainstorming/SKILL.md`
 - Role: inline design clarification and planner handoff
 - Allowed edits: clarification wording, design template structure, handoff wording, save examples
@@ -37,7 +40,17 @@ copy.
 - Comparison references: `metaswarm` clarification discipline, `get-shit-done` design-before-plan behavior
 - Review requirement: audit + replay + manual semantic review
 
+### memory-and-handoff
+
+- Path: `plugins/cc10x/skills/memory-and-handoff/SKILL.md`
+- Role: persist context across compaction; portable handoff package
+- Allowed edits: memory-file contract wording, context-budget guidance, checkpoint examples
+- Forbidden edits: changing the `.cc10x/*.md` ownership law (router persists at workflow-final, agents emit Memory Notes), bypassing router-owned memory finalization
+- Comparison references: `metaswarm` artifact persistence, `get-shit-done` context-recovery
+- Review requirement: audit + replay + manual semantic review
+
 ### component-builder
+
 - Path: `plugins/cc10x/agents/component-builder.md`
 - Role: current approved phase execution
 - Allowed edits: TDD wording, anti-scope-creep wording, evidence phrasing, context-curation wording
@@ -46,6 +59,7 @@ copy.
 - Review requirement: audit + replay + manual semantic review
 
 ### integration-verifier
+
 - Path: `plugins/cc10x/agents/integration-verifier.md`
 - Role: fail-closed independent end-to-end verification
 - Allowed edits: evidence wording, auditor tone, truths/artifacts/wiring exposition, output clarity
@@ -54,6 +68,7 @@ copy.
 - Review requirement: audit + replay + manual semantic review
 
 ### plan-review-gate
+
 - Path: `plugins/cc10x/skills/plan-review-gate/SKILL.md`
 - Role: fail-closed plan review boundary
 - Allowed edits: adversarial tone, wording clarity, evidence expectations
@@ -62,6 +77,7 @@ copy.
 - Review requirement: audit + replay + manual semantic review
 
 ### verification-before-completion
+
 - Path: `plugins/cc10x/skills/verification-before-completion/SKILL.md`
 - Role: fresh-evidence honesty layer before completion claims
 - Allowed edits: compactness, anti-rationalization wording, live-proof wording, example cleanup
@@ -72,6 +88,7 @@ copy.
 ## Tier 2: Strong Supporting Contracts
 
 ### plan-gap-reviewer
+
 - Path: `plugins/cc10x/agents/plan-gap-reviewer.md`
 - Role: fresh, read-only challenge pass for saved plans
 - Allowed edits: reviewer wording, finding categories, evidence language, anti-anchoring rules
@@ -80,6 +97,7 @@ copy.
 - Review requirement: audit + targeted semantic review
 
 ### bug-investigator
+
 - Path: `plugins/cc10x/agents/bug-investigator.md`
 - Role: evidence-first debugging with variant and blast-radius coverage
 - Allowed edits: hypothesis wording, anti-hardcode wording, anti-loop wording, context-curation wording
@@ -88,6 +106,7 @@ copy.
 - Review requirement: audit + targeted semantic review
 
 ### session-memory
+
 - Path: `plugins/cc10x/skills/session-memory/SKILL.md`
 - Role: versioned memory load discipline, distillation rules, and router-subordinate memory-note protocol
 - Allowed edits: compactness, reference navigation, distillation wording, context-budget guidance, and examples that preserve current ownership
@@ -96,6 +115,7 @@ copy.
 - Review requirement: audit + targeted semantic review
 
 ### code-reviewer
+
 - Path: `plugins/cc10x/agents/code-reviewer.md`
 - Role: adversarial code review with remediation intent
 - Allowed edits: rubric clarity, evidence language, confidence wording
@@ -104,6 +124,7 @@ copy.
 - Review requirement: audit + targeted semantic review
 
 ### silent-failure-hunter
+
 - Path: `plugins/cc10x/agents/silent-failure-hunter.md`
 - Role: scan for silent-failure patterns and report truthful coverage
 - Allowed edits: scan-language clarity, severity wording, output clarity
@@ -114,6 +135,7 @@ copy.
 ## Tier 3: Advisory Skill Metadata
 
 ### frontend-patterns
+
 - Path: `plugins/cc10x/skills/frontend-patterns/SKILL.md`
 - Role: advisory frontend guardrails and spec-aligned project-local DESIGN.md authoring guidance
 - Allowed edits: trigger accuracy, brevity, advisory clarifications, reference navigation, checklist extraction, DESIGN.md authoring guidance
@@ -122,6 +144,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### debugging-patterns
+
 - Path: `plugins/cc10x/skills/debugging-patterns/SKILL.md`
 - Role: advisory root-cause debugging reference
 - Allowed edits: trigger accuracy, brevity, root-cause emphasis, reference navigation, playbook extraction
@@ -130,6 +153,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### code-review-patterns
+
 - Path: `plugins/cc10x/skills/code-review-patterns/SKILL.md`
 - Role: advisory review-order, security, and quality heuristics
 - Allowed edits: compactness, rubric clarity, reference navigation, checklist extraction
@@ -138,6 +162,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### test-driven-development
+
 - Path: `plugins/cc10x/skills/test-driven-development/SKILL.md`
 - Role: advisory TDD discipline and verification-depth escalation
 - Allowed edits: compactness, examples, reference navigation, live-proof escalation wording
@@ -146,6 +171,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### architecture-patterns
+
 - Path: `plugins/cc10x/skills/architecture-patterns/SKILL.md`
 - Role: advisory architecture lens
 - Allowed edits: trigger accuracy, advisory framing
@@ -154,6 +180,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### prototyping
+
 - Path: `plugins/cc10x/skills/prototyping/SKILL.md`
 - Role: advisory throwaway-spike mode (answer ONE design question, then delete-or-absorb)
 - Allowed edits: trigger accuracy, branch guidance, close-out/disposition wording
@@ -162,6 +189,7 @@ copy.
 - Review requirement: audit only unless the hard-wall or precedence wording changes
 
 ### finding-duplicate-functions
+
 - Path: `plugins/cc10x/skills/finding-duplicate-functions/SKILL.md`
 - Role: advisory semantic-duplicate audit for LLM-grown codebases (loaded by the reviewer or run standalone)
 - Allowed edits: phase clarity, high-risk-zone table, model-tier wiring, common-mistakes
@@ -170,6 +198,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### mcp-cli
+
 - Path: `plugins/cc10x/skills/mcp-cli/SKILL.md`
 - Role: advisory on-demand MCP invocation (transient, not permanently mounted)
 - Allowed edits: discovery/call/cleanup flow, install prereq, guard safety pattern
@@ -178,6 +207,7 @@ copy.
 - Review requirement: audit only unless authority wording changes
 
 ### receiving-code-review
+
 - Path: `plugins/cc10x/skills/receiving-code-review/SKILL.md`
 - Role: main-session discipline for verifying human/external review feedback before agreeing or implementing
 - Allowed edits: the 6-step loop, forbidden-responses table, YAGNI-grep step, when-to-push-back
@@ -186,6 +216,7 @@ copy.
 - Review requirement: audit only unless authority/precedence wording changes
 
 ### codebase-deepening
+
 - Path: `plugins/cc10x/skills/codebase-deepening/SKILL.md`
 - Role: advisory retrofit/deepening analysis for shallow modules in existing code (read-only; proposes, does not edit)
 - Allowed edits: deletion-test framing, diagnosis flow, candidate-badge presentation, two-adapters seam application
@@ -194,6 +225,7 @@ copy.
 - Review requirement: audit only unless it stops routing refactors through BUILD
 
 ### frontend-design-critique
+
 - Path: `plugins/cc10x/skills/frontend-design-critique/SKILL.md`
 - Role: read-only design-quality critique (two isolated assessments + anchored rubric + AI-slop ban-list)
 - Allowed edits: rubric criteria, ban-list maintenance, isolation/synthesis protocol, RTL notes
@@ -202,6 +234,7 @@ copy.
 - Review requirement: audit only unless it competes with frontend-patterns authority
 
 ### handoff-package
+
 - Path: `plugins/cc10x/skills/handoff-package/SKILL.md`
 - Role: portable cross-session/cross-tool handoff doc (repo-external, reference-by-path, secrets-redacted)
 - Allowed edits: doc contents, location recipe, suggested-skills pointer
@@ -212,6 +245,7 @@ copy.
 ## Review Classification
 
 Every prompt change must be classified before merge:
+
 - `metadata_only`
 - `wording_only_low_risk`
 - `wording_only_trust_sensitive`

--- a/docs/router-invariants.md
+++ b/docs/router-invariants.md
@@ -1,6 +1,6 @@
 # CC10x Router Behavioral Invariant Registry
 
-> **Status note:** Current product line is `v11.0.0`. This registry is aligned to the live router structure in `plugins/cc10x/skills/cc10x-router/SKILL.md` and `plugins/cc10x/skills/cc10x-router/references/*.md` as of 2026-06-17. Structural contract last changed on 2026-04-12 (`v10.1.19`); `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/` (version lives only in `plugin.json`/GitHub) with no invariant changes. `v11.1.0` adds execution-engine scripts (`cc10x_phase_brief`, `cc10x_review_package`), recorded-BASE diffing, an inline no-subagent fallback, and 4 net-new skills — additive, no invariant changes.
+> **Status note:** Current product line is `v11.0.0`. This registry is aligned to the live router structure in `plugins/cc10x/skills/cc10x-router/SKILL.md` and `plugins/cc10x/skills/cc10x-router/references/*.md` as of 2026-06-17. Structural contract last changed on 2026-04-12 (`v10.1.19`); `v11.0.0` de-versions the state root from `.cc10x/v10/` to `.cc10x/` (version lives only in `plugin.json`/GitHub) with no invariant changes. `v11.1.0` adds execution-engine scripts (`cc10x_phase_brief`, `cc10x_review_package`), recorded-BASE diffing, an inline no-subagent fallback, and 4 net-new skills — additive, no invariant changes. `v12.5.0` adds the enforced seam gate (TEST_SEAMS/SEAM_GATE_STATUS contract fields), resolving-merge-conflicts skill, and 2 advisory on-ramp workflows (TRIAGE, CODEBASE-HEALTH) at routing priority 5/6 — additive, no invariant changes to priority 1-4 routes.
 
 ## Purpose
 
@@ -10,6 +10,7 @@ If a router section changes, the matching invariant must be updated in the same 
 ## Audit Snapshot
 
 Validated against the live plugin surface:
+
 - workflow artifacts under `.cc10x/workflows/{wf}.json`
 - workflow event logs under `.cc10x/workflows/{wf}.events.jsonl`
 - plugin hooks in `plugins/cc10x/hooks/hooks.json`
@@ -24,104 +25,122 @@ Validated against the live plugin surface:
 ## Current Invariants
 
 ### INV-027: Router kernel must explicitly load mandatory references
+
 **Covers:** Router `## 2a. Workflow Artifact And Hook Policy`, `## 5. Workflow Preparation`, `## 6. Workflow Task Graphs`, and `plugins/cc10x/skills/cc10x-router/references/*.md`
 **Enforces:** Universal orchestration law stays inline in the router kernel while workflow-specific and appendix-heavy law remains in one-level-deep references that are named explicitly at each decision point.
 **If removed:** Either the router swells back into a monolith, or branch-specific orchestration rules become optional context that Claude may skip under pressure.
 **Safe to remove:** Never.
 
 ### INV-025: Latency telemetry is informational only
+
 **Covers:** Router workflow artifact schema, workflow event log, latency audit tooling
 **Enforces:** Timing fields, loop counters, and verifier workload breakdowns may inform optimization work, but they may not change routing, approval, remediation, or phase-advance decisions by themselves.
 **If removed:** Performance instrumentation can quietly become a second decision system and weaken trust gates under the banner of speed.
 **Safe to remove:** Never.
 
 ### INV-021: Router owns plan mode selection semantics
+
 **Covers:** Router `## 5. Workflow Preparation`, planner contract, replay fixtures
 **Enforces:** Every planning artifact declares exactly one `plan_mode` and the router treats `direct`, `execution_plan`, and `decision_rfc` as different safety levels.
 **If removed:** Architecture work can regress into weak direct plans and broad work can bypass the stronger decision-grade contract.
 **Safe to remove:** Never.
 
 ### INV-022: Spec gate is a blocking trust boundary
+
 **Covers:** Router `## 5. Workflow Preparation`, `plan-review-gate`, `## 8. Post-Agent Validation`
 **Enforces:** Planner artifacts must survive feasibility, completeness, and alignment review before BUILD may start.
 **If removed:** Planner defaults and hidden assumptions can leak straight into execution again.
 **Safe to remove:** Never.
 
 ### INV-026: Fresh planning review is bounded and planner-owned
+
 **Covers:** Router `## 5. Workflow Preparation`, `## 9. Remediation And Workflow Rules`, planner, `plan-gap-reviewer`
 **Enforces:** Every PLAN workflow pre-creates a DAG-visible bounded review chain (`plan-create -> plan-review-gap-1 -> re-plan -> plan-review-gap-2 -> memory-finalize`), while the planner remains the only writer, the router remains the only orchestration owner, and the loop is capped at two reviewer passes.
 **If removed:** PLAN can drift into hidden dynamic orchestration, ambiguous plan ownership, or open-ended token-heavy refinement loops that are not auditable from the task graph.
 **Safe to remove:** Never.
 
 ### INV-023: Proof status gates phase completion
+
 **Covers:** Router `## 5. Workflow Preparation`, `## 8. Post-Agent Validation`, BUILD/VERIFY prompts
 **Enforces:** `proof_status` remains `gaps_found` until truths, artifacts, and wiring are reconciled; BUILD does not advance on narrative confidence alone.
 **If removed:** CC10X can report completed work that never proved the actual user outcome.
 **Safe to remove:** Never.
 
 ### INV-024: Traceability is durable across planning, execution, and remediation
+
 **Covers:** Router artifact schema, replay fixtures, memory finalization
 **Enforces:** Requirements, phases, verification, and remediation keep an explicit link chain in the workflow artifact.
 **If removed:** The system becomes harder to audit, harder to resume safely, and easier to bluff with prose.
 **Safe to remove:** Never.
 
 ### INV-001: Workflow artifact creation is immediate and durable
+
 **Covers:** Router `## 2a. Workflow Artifact And Hook Policy`, `## 6. Workflow Task Graphs`, `references/workflow-artifact-and-hook-policy.md`
 **Enforces:** Every workflow gets a JSON artifact and append-only event log under the v10 namespace as soon as the workflow UUID is known.
 **If removed:** Resume, verifier handoff, research quality tracking, and hook-based context injection become conversation-dependent and non-durable.
 **Safe to remove:** Never.
 
 ### INV-002: Workflow identity is stable and task-id independent
+
 **Covers:** Router `## 3. Task Metadata Contract`, `## 6. Workflow Task Graphs`
 **Enforces:** Router generates a stable workflow UUID before task creation and uses that UUID across artifacts, event logs, task metadata, resume, and hook context.
 **If removed:** Child tasks can collide across sessions and hydration can attach to the wrong workflow.
 **Safe to remove:** Never.
 
 ### INV-003: Every CC10X child task is workflow-scoped
+
 **Covers:** Router `## 3. Task Metadata Contract`
 **Enforces:** Child tasks must carry `wf`, `kind`, `origin`, `phase`, `plan`, `scope`, and `reason`.
 **If removed:** Resume, remediation counting, and re-review routing degrade into subject parsing and shared-task-list collisions.
 **Safe to remove:** Never.
 
 ### INV-004: Router is the only orchestration owner
+
 **Covers:** Router `## 7. Dispatcher And Agent Prompt Contract`, `## 9. Remediation And Workflow Rules`, `## 11. Re-Review Loop`
 **Enforces:** Workers emit contracts and remediation intent; the router creates, blocks, resumes, and completes orchestration tasks.
 **If removed:** Reviewer/verifier drift back into mutating orchestration state and task ownership becomes ambiguous again.
 **Safe to remove:** Never.
 
 ### INV-005: Scope decision is a first-class BUILD pause
+
 **Covers:** Router `## 8. Post-Agent Validation`, `## 9. Remediation And Workflow Rules`
 **Enforces:** Mixed CRITICAL + HIGH findings in BUILD pause for explicit scope selection before remediation is created.
 **If removed:** HIGH issues are silently dropped when CRITICAL-only fixes are chosen by default.
 **Safe to remove:** Only if re-hunt is forced to `ALL_ISSUES` in every BUILD remediation path.
 
 ### INV-006: Remediation loops are workflow-scoped and bounded
+
 **Covers:** Router `## 9. Remediation And Workflow Rules`, `## 11. Re-Review Loop`, `references/remediation-and-research.md`
 **Enforces:** `kind:remfix` counting, re-review task creation, and cycle limits all use the current `wf` scope.
 **If removed:** Remediation loops can count unrelated tasks, overrun, or deadlock in shared task lists.
 **Safe to remove:** Never.
 
 ### INV-007: Research quality is durable, not conversational
+
 **Covers:** Router `## 10. Research Orchestration`, `## Research Quality`, `## Research Files`, `references/remediation-and-research.md`
 **Enforces:** Research backend choice, quality level, and file paths are written into workflow artifacts and passed forward explicitly.
 **If removed:** Planner/debugger decisions begin depending on transient research prose and old memory references.
 **Safe to remove:** Never.
 
 ### INV-008: Read-only outputs fail closed
+
 **Covers:** Router `## 8. Post-Agent Validation`
 **Enforces:** Read-only agent outputs must produce a valid contract signal, and verifier scenario totals must reconcile with evidence.
 **If removed:** APPROVE / CLEAN / PASS can slip through with malformed evidence or incomplete verification.
 **Safe to remove:** Never.
 
 ### INV-009: Write-agent contracts fail closed
+
 **Covers:** Router `## 8. Post-Agent Validation`
 **Enforces:** BUILD / DEBUG / PLAN outputs must contain the expected YAML contract fields and satisfy pass rules before the workflow advances.
 **If removed:** Builder, investigator, or planner can self-report success without enough proof.
 **Safe to remove:** Never.
 
 ### INV-010: Scenario evidence gates BUILD, DEBUG, and VERIFY
+
 **Covers:** Router `## 8. Post-Agent Validation`
 **Enforces:**
+
 - BUILD requires at least one passing named scenario with concrete command/expected/actual proof
 - DEBUG requires regression plus variant evidence when a fix is claimed
 - VERIFY requires scenario totals to match evidence rows
@@ -129,56 +148,66 @@ Validated against the live plugin surface:
 **Safe to remove:** Never.
 
 ### INV-011: Convergence state blocks “good enough” progression
+
 **Covers:** Router `## 8. Post-Agent Validation`, `## 12. Chain Execution Loop`
 **Enforces:** Incomplete or contradictory evidence sets `quality.convergence_state=needs_iteration` and stops workflow advancement.
 **If removed:** The system starts silently tolerating partial proof and ambiguous completion.
 **Safe to remove:** Never.
 
 ### INV-015: Open decisions block BUILD
+
 **Covers:** Router `## 5. Workflow Preparation`, `## 8. Post-Agent Validation`
 **Enforces:** Plans with unresolved open decisions or missing `Differences From Agreement` cannot transition into BUILD.
 **If removed:** Planner defaults begin masquerading as approved requirements again.
 **Safe to remove:** Never.
 
 ### INV-016: Phase exit is the only way BUILD advances
+
 **Covers:** Router `## 6. Workflow Task Graphs`, `## 8. Post-Agent Validation`, `## 12. Chain Execution Loop`
 **Enforces:** BUILD advances `phase_cursor` only after RED, GREEN, and phase-exit evidence are complete with no unresolved blocked items.
 **If removed:** BUILD can skip steps, reorder work, or continue after partial execution.
 **Safe to remove:** Never.
 
 ### INV-017: Internal skills are advisory
+
 **Covers:** Router `## 7. Dispatcher And Agent Prompt Contract`, internal skills
 **Enforces:** Explicit user instructions, `CLAUDE.md`, repo standards, and approved plans outrank CC10X internal skills.
 **If removed:** `frontend-patterns` / `architecture-patterns` / `debugging-patterns` can silently compete with user intent again.
 **Safe to remove:** Never.
 
 ### INV-018: Agents use only the v10 state namespace
+
 **Covers:** Router `## 2. Memory Load And Template Validation`, agent memory-read sections
 **Enforces:** BUILD / DEBUG / REVIEW / VERIFY agents read from `.cc10x/*.md` only and never mix legacy memory paths into active orchestration.
 **If removed:** Agents can read stale state, leak legacy decisions into live workflows, or disagree about the active workflow memory surface.
 **Safe to remove:** Never.
 
 ### INV-019: Verification is independent of upstream approval
+
 **Covers:** Router `## 8. Post-Agent Validation`, verifier contract, BUILD chain
 **Enforces:** Reviewer approval, hunter CLEAN, or builder success are inputs to verification, not substitutes for independent scenario proof.
 **If removed:** The workflow can regress into self-certified completion where one agent's confidence is mistaken for verification.
 **Safe to remove:** Never.
 
 ### INV-020: Silent-failure analysis must state scan coverage truthfully
+
 **Covers:** Router `## 8. Post-Agent Validation`, hunter contract
 **Enforces:** The silent-failure hunter must describe scanned scope and blind spots before a CLEAN result is accepted.
 **If removed:** CLEAN verdicts can hide incomplete search coverage and create false confidence in error-handling quality.
 **Safe to remove:** Never.
 
 ### INV-012: Memory finalization is router-owned and compaction-safe
+
 **Covers:** Router `## 12. Chain Execution Loop`, `## 13. Memory Finalization`, `references/build-workflow.md`, `references/debug-workflow.md`, `references/review-workflow.md`, `references/plan-workflow.md`
 **Enforces:** Read-only Memory Notes are copied into the memory task immediately; final persistence happens inline through the Memory Update task; transient `memory_task_id` is removed on completion; and a `kind:memory` task is not considered trustworthy unless the workflow event log records `memory_finalized`.
 **If removed:** Memory becomes conversation-dependent or leaks stale workflow pointers across sessions.
 **Safe to remove:** Never.
 
 ### INV-013: Plugin hooks are guardrails, not orchestration
+
 **Covers:** Router `## 2a. Workflow Artifact And Hook Policy`, `references/workflow-artifact-and-hook-policy.md`, plugin hooks
 **Enforces:** Hooks remain minimal and audit-first:
+
 - `PreToolUse` protects memory writes
 - `SessionStart` injects workflow context
 - `PostToolUse` audits workflow artifact integrity
@@ -187,6 +216,7 @@ Validated against the live plugin surface:
 **Safe to remove:** Only if an equivalent plugin-native guardrail replaces the specific hook behavior.
 
 ### INV-014: Workflow replay fixtures are part of the safety contract
+
 **Covers:** `plugins/cc10x/scripts/cc10x_workflow_replay_check.py`, `plugins/cc10x/tests/fixtures/`
 **Enforces:** PLAN / BUILD / DEBUG / REVIEW / VERIFY decision paths are regression-checked without relying on a live Claude session.
 **If removed:** Future router/prompt edits can regress core orchestration behavior without a deterministic detection path.
@@ -195,6 +225,7 @@ Validated against the live plugin surface:
 ## Legacy Appendix
 
 Pre-`v9.x` invariants were reorganized rather than preserved one-for-one. Historical context remains in git history. The current source of truth is this live registry plus:
+
 - `plugins/cc10x/skills/cc10x-router/SKILL.md`
 - `plugins/cc10x/scripts/cc10x_harness_audit.py`
 - `plugins/cc10x/scripts/cc10x_workflow_replay_check.py`


### PR DESCRIPTION
## Summary

Release-sync: fixes all 7 pre-existing `harness_audit` failures that every reviewer flagged across all 3 review rounds. This is the last "open issue" standing between shipped-with-a-flag and shipped-clean.

**Merge order:** #56 (2a) → #63 (2b) → **this PR** (the docs reference v12.5.0 features those PRs add).

## What changed (7 files, +217/-15)

1. **CHANGELOG.md** — added the `[12.5.0]` release section (sub-projects 1, 2a, 2b + verification infra + fixes)
2. **prompt-surface-inventory.md** — added the missing `### memory-and-handoff` entry
3. **router-invariants.md** — synced to v12.5.0
4. **prompt-invariants.md** — synced to v12.5.0
5. **cc10x-orchestration-bible.md** — synced to v12.5.0
6. **cc10x-orchestration-logic-analysis.md** — synced to v12.5.0
7. **agent-contract-registry.md** — synced to v12.5.0

## Verification (fresh, this turn — all exit 0)

| Gate | Result |
|---|---|
| `harness_audit` | **OK** (was 7 FAIL) |
| `doc_consistency_check` | OK |
| `prompt_clause_assertions` | OK |
| `workflow_replay_check` | OK (28 fixtures) |

## Why this is the "0 flaws" PR

This was the single recurring issue across all 3 GPT-5.6 Sol review rounds (sub-project 1, 2a, 2b) — flagged as "pre-existing, not caused by this work, separate release-sync." Now it's done. After #56 + #63 + this PR merge, `harness_audit` is green and there are zero open flags.
